### PR TITLE
chore: add an end to end parsing test

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,6 +7,7 @@ name = "python"
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+  max_line_length = 100
   type_checker = "mypy"
 
 [[analyzers]]

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ venv*
 **/*.egg-info
 **/build
 **/dist
+coverage.xml
+.env
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /home/runner /app /artifacts /toolbox \
 
 RUN apk add --no-cache git grep
 
-COPY ./sarif-parser /toolbox/sarif-parser
+COPY . /toolbox/
 
 RUN pip install --no-cache-dir /toolbox/sarif-parser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN mkdir -p /home/runner /app /artifacts /toolbox \
 RUN apk add --no-cache git grep
 
 COPY . /toolbox/
+# Change working dir to toolbox since we'd be invoking community analyzer from there.
+WORKDIR /toolbox
 
-RUN pip install --no-cache-dir /toolbox/sarif-parser -r /toolbox/requirements.txt
+# Install parser and the required dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
 USER runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,5 @@ RUN apk add --no-cache git grep
 
 COPY . /toolbox/
 
-RUN pip install --no-cache-dir /toolbox/sarif-parser
-
+RUN pip install --no-cache-dir /toolbox/sarif-parser -r /toolbox/requirements.txt
 USER runner

--- a/README.md
+++ b/README.md
@@ -42,14 +42,16 @@ The following are very important to sync analyzers with DeepSource:
     - `severity`: Severity of the issue. Allowed values are: "critical", "major" and "minor".
 
 3. `CI` directory:
-Put example configs of all CIs under this directory. These worlflow / CI configs should run the analyzer, create a sarif report and send it to DeepSource.
-Each file should be names as `<provider>.<extention>`. Example: `github.yml`, `circleci.yml`, etc.`
 
-4. `utils` directory:
-It should contain all the utilities required for the analyzer like issue genrator, issue-map, etc.
-For example, please check out `analyzers/kube-linter/utils`.
+  Put example configs of all CIs under this directory. These worlflow / CI configs should run the analyzer, create a sarif report and send it to DeepSource.
+  Each file should be names as `<provider>.<extention>`. Example: `github.yml`, `circleci.yml`, etc.`
 
-5. Add a sample sarif report from the analyzer in `tests/fixtures` directory. The file should be named as `<analyzer-shortcode>.sarif`.
+5. `utils` directory:
+
+  It should contain all the utilities required for the analyzer like issue genrator, issue-map, etc.
+  For example, please check out `analyzers/kube-linter/utils`.
+
+6. Add a sample sarif report from the analyzer in `tests/fixtures` directory. The file should be named as `<analyzer-shortcode>.sarif`.
 `test_report_parsing` parses all sarif reports under the given directory and checks if the issues are parsed correctly. It is important for that particular test to pass.
 
 ### Syncing analyzers and their issues with DeepSource

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ The following are very important to sync analyzers with DeepSource:
   Put example configs of all CIs under this directory. These worlflow / CI configs should run the analyzer, create a sarif report and send it to DeepSource.
   Each file should be names as `<provider>.<extention>`. Example: `github.yml`, `circleci.yml`, etc.`
 
-5. `utils` directory:
+4. `utils` directory:
 
   It should contain all the utilities required for the analyzer like issue genrator, issue-map, etc.
   For example, please check out `analyzers/kube-linter/utils`.
 
-6. Add a sample sarif report from the analyzer in `tests/fixtures` directory. The file should be named as `<analyzer-shortcode>.sarif`.
+5. Add a sample sarif report from the analyzer in `tests/fixtures` directory. The file should be named as `<analyzer-shortcode>.sarif`.
 `test_report_parsing` parses all sarif reports under the given directory and checks if the issues are parsed correctly. It is important for that particular test to pass.
 
 ### Syncing analyzers and their issues with DeepSource

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The following are very important to sync analyzers with DeepSource:
 
     c. `logo.svg` file.
 
-
 2. `.deepsource/issues` directory. This contains all issues detected by the analyzer. Each issue's filemane should be `<issue-shortcode>.toml` or `<issue-shortcode.md>` with the following fields:
 
     - `title`: Title of the issue. No periods are allowed in the title.
@@ -43,14 +42,15 @@ The following are very important to sync analyzers with DeepSource:
     - `severity`: Severity of the issue. Allowed values are: "critical", "major" and "minor".
 
 3. `CI` directory:
-
 Put example configs of all CIs under this directory. These worlflow / CI configs should run the analyzer, create a sarif report and send it to DeepSource.
 Each file should be names as `<provider>.<extention>`. Example: `github.yml`, `circleci.yml`, etc.`
 
 4. `utils` directory:
-
 It should contain all the utilities required for the analyzer like issue genrator, issue-map, etc.
 For example, please check out `analyzers/kube-linter/utils`.
+
+5. Add a sample sarif report from the analyzer in `tests/fixtures` directory. The file should be named as `<analyzer-shortcode>.sarif`.
+`test_report_parsing` parses all sarif reports under the given directory and checks if the issues are parsed correctly. It is important for that particular test to pass.
 
 ### Syncing analyzers and their issues with DeepSource
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+./sarif-parser
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-./sarif-parser
 sentry-sdk

--- a/sarif-parser/tests/cli_test.py
+++ b/sarif-parser/tests/cli_test.py
@@ -188,7 +188,28 @@ def test_cli_with_issue_map(
     assert out == expected_output
 
 
+def test_cli_with_invalid_issue_map_path(
+    artifact_path: str,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Tests `sarif-parser` CLI, with an invalid issue_map path"""
+    cli([artifact_path, "--issue-map-path=some/invalid/path", "--output=/dev/stdout"])
+    out, err = capfd.readouterr()
+    assert err == ""
+
+    expected_output = json.dumps(
+        {
+            "issues": expected_issues,  # without issues map since we have passed an invalid path
+            "metrics": [],
+            "errors": [],
+            "is_passed": False,
+            "extra_data": {},
+        }
+    )
+    assert out == expected_output
+
+
 def test_cli_file_not_found() -> None:
     """Tests `sarif-parser` CLI, with issue code substitution."""
     with pytest.raises(FileNotFoundError):
-        cli(["/tmp/doesnotexist.py"])
+        cli(["/some/doesnotexist.py"])

--- a/sentry.py
+++ b/sentry.py
@@ -1,7 +1,15 @@
 import os
+import logging
 
 import sentry_sdk
 import sentry_sdk.utils
+
+
+logger = logging.getLogger("community_analyzer")
+# Configure the logging format to also include file, linenum.
+logging.basicConfig(format='%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+    datefmt='%Y-%m-%d:%H:%M:%S',
+    level=logging.DEBUG)
 
 
 def initialize() -> None:
@@ -32,3 +40,6 @@ def raise_info(message: str, context: dict[str, object] | None = None) -> None:
                 scope.set_extra(context_name, context_value)
         # Capture the message
         sentry_sdk.capture_message(message)
+
+    # Add a log for this
+    logger.info(message, extra=context)

--- a/sentry.py
+++ b/sentry.py
@@ -1,15 +1,16 @@
-import os
 import logging
+import os
 
 import sentry_sdk
 import sentry_sdk.utils
 
-
 logger = logging.getLogger("community_analyzer")
 # Configure the logging format to also include file, linenum.
-logging.basicConfig(format='%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
-    datefmt='%Y-%m-%d:%H:%M:%S',
-    level=logging.DEBUG)
+logging.basicConfig(
+    format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
+    datefmt="%Y-%m-%d:%H:%M:%S",
+    level=logging.DEBUG,
+)
 
 
 def initialize() -> None:

--- a/tests/fixtures/reports/kube-linter.sarif
+++ b/tests/fixtures/reports/kube-linter.sarif
@@ -1,0 +1,1011 @@
+{
+    "version": "2.1.0",
+    "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "informationUri": "https://github.com/stackrox/kube-linter",
+                    "name": "kube-linter",
+                    "rules": [
+                        {
+                            "id": "dangling-service",
+                            "shortDescription": {
+                                "text": "Indicates when services do not have any associated deployments."
+                            },
+                            "fullDescription": {
+                                "text": "Confirm that your service's selector correctly matches the labels on one of your deployments."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=dangling-services",
+                            "help": {
+                                "text": "Check: dangling-service\nDescription: Indicates when services do not have any associated deployments.\nRemediation: Confirm that your service's selector correctly matches the labels on one of your deployments.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=dangling-services"
+                            }
+                        },
+                        {
+                            "id": "deprecated-service-account-field",
+                            "shortDescription": {
+                                "text": "Indicates when deployments use the deprecated serviceAccount field."
+                            },
+                            "fullDescription": {
+                                "text": "Use the serviceAccountName field instead. If you must specify serviceAccount, ensure values for serviceAccount and serviceAccountName match."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=deprecated-service-account-field",
+                            "help": {
+                                "text": "Check: deprecated-service-account-field\nDescription: Indicates when deployments use the deprecated serviceAccount field.\nRemediation: Use the serviceAccountName field instead. If you must specify serviceAccount, ensure values for serviceAccount and serviceAccountName match.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=deprecated-service-account-field"
+                            }
+                        },
+                        {
+                            "id": "docker-sock",
+                            "shortDescription": {
+                                "text": "Alert on deployments with docker.sock mounted in containers. "
+                            },
+                            "fullDescription": {
+                                "text": "Ensure the Docker socket is not mounted inside any containers by removing the associated  Volume and VolumeMount in deployment yaml specification. If the Docker socket is mounted inside a container it could allow processes running within  the container to execute Docker commands which would effectively allow for full control of the host."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=host-mounts",
+                            "help": {
+                                "text": "Check: docker-sock\nDescription: Alert on deployments with docker.sock mounted in containers. \nRemediation: Ensure the Docker socket is not mounted inside any containers by removing the associated  Volume and VolumeMount in deployment yaml specification. If the Docker socket is mounted inside a container it could allow processes running within  the container to execute Docker commands which would effectively allow for full control of the host.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=host-mounts"
+                            }
+                        },
+                        {
+                            "id": "drop-net-raw-capability",
+                            "shortDescription": {
+                                "text": "Indicates when containers do not drop NET_RAW capability"
+                            },
+                            "fullDescription": {
+                                "text": "NET_RAW makes it so that an application within the container is able to craft raw packets, use raw sockets, and bind to any address. Remove this capability in the containers under containers security contexts."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=verify-container-capabilities",
+                            "help": {
+                                "text": "Check: drop-net-raw-capability\nDescription: Indicates when containers do not drop NET_RAW capability\nRemediation: NET_RAW makes it so that an application within the container is able to craft raw packets, use raw sockets, and bind to any address. Remove this capability in the containers under containers security contexts.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=verify-container-capabilities"
+                            }
+                        },
+                        {
+                            "id": "duplicate-env-var",
+                            "shortDescription": {
+                                "text": "Check that duplicate named env vars aren't passed to a deployment like."
+                            },
+                            "fullDescription": {
+                                "text": "Confirm that your DeploymentLike doesn't have duplicate env vars names."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=duplicate-environment-variables",
+                            "help": {
+                                "text": "Check: duplicate-env-var\nDescription: Check that duplicate named env vars aren't passed to a deployment like.\nRemediation: Confirm that your DeploymentLike doesn't have duplicate env vars names.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=duplicate-environment-variables"
+                            }
+                        },
+                        {
+                            "id": "env-var-secret",
+                            "shortDescription": {
+                                "text": "Indicates when objects use a secret in an environment variable."
+                            },
+                            "fullDescription": {
+                                "text": "Do not use raw secrets in environment variables. Instead, either mount the secret as a file or use a secretKeyRef. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets for details."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=environment-variables",
+                            "help": {
+                                "text": "Check: env-var-secret\nDescription: Indicates when objects use a secret in an environment variable.\nRemediation: Do not use raw secrets in environment variables. Instead, either mount the secret as a file or use a secretKeyRef. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets for details.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=environment-variables"
+                            }
+                        },
+                        {
+                            "id": "host-ipc",
+                            "shortDescription": {
+                                "text": "Alert on pods/deployment-likes with sharing host's IPC namespace"
+                            },
+                            "fullDescription": {
+                                "text": "Ensure the host's IPC namespace is not shared."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=host-ipc",
+                            "help": {
+                                "text": "Check: host-ipc\nDescription: Alert on pods/deployment-likes with sharing host's IPC namespace\nRemediation: Ensure the host's IPC namespace is not shared.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=host-ipc"
+                            }
+                        },
+                        {
+                            "id": "host-network",
+                            "shortDescription": {
+                                "text": "Alert on pods/deployment-likes with sharing host's network namespace"
+                            },
+                            "fullDescription": {
+                                "text": "Ensure the host's network namespace is not shared."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=host-network",
+                            "help": {
+                                "text": "Check: host-network\nDescription: Alert on pods/deployment-likes with sharing host's network namespace\nRemediation: Ensure the host's network namespace is not shared.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=host-network"
+                            }
+                        },
+                        {
+                            "id": "host-pid",
+                            "shortDescription": {
+                                "text": "Alert on pods/deployment-likes with sharing host's process namespace"
+                            },
+                            "fullDescription": {
+                                "text": "Ensure the host's process namespace is not shared."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=host-pid",
+                            "help": {
+                                "text": "Check: host-pid\nDescription: Alert on pods/deployment-likes with sharing host's process namespace\nRemediation: Ensure the host's process namespace is not shared.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=host-pid"
+                            }
+                        },
+                        {
+                            "id": "invalid-target-ports",
+                            "shortDescription": {
+                                "text": "Indicates when deployments or services are using port names that are violating specifications."
+                            },
+                            "fullDescription": {
+                                "text": "Ensure that port naming is in conjunction with the specification. For more information, please look at the Kubernetes Service specification on this page: https://kubernetes.io/docs/reference/_print/#ServiceSpec. And additional information about IANA Service naming can be found on the following page: https://www.rfc-editor.org/rfc/rfc6335.html#section-5.1."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=target-port",
+                            "help": {
+                                "text": "Check: invalid-target-ports\nDescription: Indicates when deployments or services are using port names that are violating specifications.\nRemediation: Ensure that port naming is in conjunction with the specification. For more information, please look at the Kubernetes Service specification on this page: https://kubernetes.io/docs/reference/_print/#ServiceSpec. And additional information about IANA Service naming can be found on the following page: https://www.rfc-editor.org/rfc/rfc6335.html#section-5.1.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=target-port"
+                            }
+                        },
+                        {
+                            "id": "latest-tag",
+                            "shortDescription": {
+                                "text": "Indicates when a deployment-like object is running a container with an invalid container image"
+                            },
+                            "fullDescription": {
+                                "text": "Use a container image with a specific tag other than latest."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=latest-tag",
+                            "help": {
+                                "text": "Check: latest-tag\nDescription: Indicates when a deployment-like object is running a container with an invalid container image\nRemediation: Use a container image with a specific tag other than latest.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=latest-tag"
+                            }
+                        },
+                        {
+                            "id": "mismatching-selector",
+                            "shortDescription": {
+                                "text": "Indicates when deployment selectors fail to match the pod template labels."
+                            },
+                            "fullDescription": {
+                                "text": "Confirm that your deployment selector correctly matches the labels in its pod template."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=mismatching-selector",
+                            "help": {
+                                "text": "Check: mismatching-selector\nDescription: Indicates when deployment selectors fail to match the pod template labels.\nRemediation: Confirm that your deployment selector correctly matches the labels in its pod template.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=mismatching-selector"
+                            }
+                        },
+                        {
+                            "id": "no-anti-affinity",
+                            "shortDescription": {
+                                "text": "Indicates when deployments with multiple replicas fail to specify inter-pod anti-affinity, to ensure that the orchestrator attempts to schedule replicas on different nodes."
+                            },
+                            "fullDescription": {
+                                "text": "Specify anti-affinity in your pod specification to ensure that the orchestrator attempts to schedule replicas on different nodes. Using podAntiAffinity, specify a labelSelector that matches pods for the deployment, and set the topologyKey to kubernetes.io/hostname. Refer to https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity for details."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=anti-affinity-not-specified",
+                            "help": {
+                                "text": "Check: no-anti-affinity\nDescription: Indicates when deployments with multiple replicas fail to specify inter-pod anti-affinity, to ensure that the orchestrator attempts to schedule replicas on different nodes.\nRemediation: Specify anti-affinity in your pod specification to ensure that the orchestrator attempts to schedule replicas on different nodes. Using podAntiAffinity, specify a labelSelector that matches pods for the deployment, and set the topologyKey to kubernetes.io/hostname. Refer to https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity for details.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=anti-affinity-not-specified"
+                            }
+                        },
+                        {
+                            "id": "no-extensions-v1beta",
+                            "shortDescription": {
+                                "text": "Indicates when objects use deprecated API versions under extensions/v1beta."
+                            },
+                            "fullDescription": {
+                                "text": "Migrate using the apps/v1 API versions for the objects. Refer to https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ for details."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=disallowed-api-objects",
+                            "help": {
+                                "text": "Check: no-extensions-v1beta\nDescription: Indicates when objects use deprecated API versions under extensions/v1beta.\nRemediation: Migrate using the apps/v1 API versions for the objects. Refer to https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ for details.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=disallowed-api-objects"
+                            }
+                        },
+                        {
+                            "id": "no-read-only-root-fs",
+                            "shortDescription": {
+                                "text": "Indicates when containers are running without a read-only root filesystem."
+                            },
+                            "fullDescription": {
+                                "text": "Set readOnlyRootFilesystem to true in the container securityContext."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=read-only-root-filesystems",
+                            "help": {
+                                "text": "Check: no-read-only-root-fs\nDescription: Indicates when containers are running without a read-only root filesystem.\nRemediation: Set readOnlyRootFilesystem to true in the container securityContext.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=read-only-root-filesystems"
+                            }
+                        },
+                        {
+                            "id": "non-existent-service-account",
+                            "shortDescription": {
+                                "text": "Indicates when pods reference a service account that is not found."
+                            },
+                            "fullDescription": {
+                                "text": "Create the missing service account, or refer to an existing service account."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=non-existent-service-account",
+                            "help": {
+                                "text": "Check: non-existent-service-account\nDescription: Indicates when pods reference a service account that is not found.\nRemediation: Create the missing service account, or refer to an existing service account.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=non-existent-service-account"
+                            }
+                        },
+                        {
+                            "id": "pdb-max-unavailable",
+                            "shortDescription": {
+                                "text": "Indicates when a PodDisruptionBudget has a maxUnavailable value that will always prevent disruptions of pods created by related deployment-like objects."
+                            },
+                            "fullDescription": {
+                                "text": "Change the PodDisruptionBudget to have maxUnavailable set to a value greater than 0. Refer to https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more information."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=no-pod-disruptions-allowed---maxunavailable",
+                            "help": {
+                                "text": "Check: pdb-max-unavailable\nDescription: Indicates when a PodDisruptionBudget has a maxUnavailable value that will always prevent disruptions of pods created by related deployment-like objects.\nRemediation: Change the PodDisruptionBudget to have maxUnavailable set to a value greater than 0. Refer to https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more information.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=no-pod-disruptions-allowed---maxunavailable"
+                            }
+                        },
+                        {
+                            "id": "pdb-min-available",
+                            "shortDescription": {
+                                "text": "Indicates when a PodDisruptionBudget sets a minAvailable value that will always prevent disruptions of pods created by related deployment-like objects."
+                            },
+                            "fullDescription": {
+                                "text": "Change the PodDisruptionBudget to have minAvailable set to a number lower than the number of replicas in the related deployment-like objects. Refer to https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more information."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=no-pod-disruptions-allowed---minavailable",
+                            "help": {
+                                "text": "Check: pdb-min-available\nDescription: Indicates when a PodDisruptionBudget sets a minAvailable value that will always prevent disruptions of pods created by related deployment-like objects.\nRemediation: Change the PodDisruptionBudget to have minAvailable set to a number lower than the number of replicas in the related deployment-like objects. Refer to https://kubernetes.io/docs/tasks/run-application/configure-pdb/ for more information.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=no-pod-disruptions-allowed---minavailable"
+                            }
+                        },
+                        {
+                            "id": "privilege-escalation-container",
+                            "shortDescription": {
+                                "text": "Alert on containers of allowing privilege escalation that could gain more privileges than its parent process."
+                            },
+                            "fullDescription": {
+                                "text": "Ensure containers do not allow privilege escalation by setting allowPrivilegeEscalation=false, privileged=false and removing CAP_SYS_ADMIN capability. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for more details."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=privilege-escalation-on-containers",
+                            "help": {
+                                "text": "Check: privilege-escalation-container\nDescription: Alert on containers of allowing privilege escalation that could gain more privileges than its parent process.\nRemediation: Ensure containers do not allow privilege escalation by setting allowPrivilegeEscalation=false, privileged=false and removing CAP_SYS_ADMIN capability. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for more details.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=privilege-escalation-on-containers"
+                            }
+                        },
+                        {
+                            "id": "privileged-container",
+                            "shortDescription": {
+                                "text": "Indicates when deployments have containers running in privileged mode."
+                            },
+                            "fullDescription": {
+                                "text": "Do not run your container as privileged unless it is required."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=privileged-containers",
+                            "help": {
+                                "text": "Check: privileged-container\nDescription: Indicates when deployments have containers running in privileged mode.\nRemediation: Do not run your container as privileged unless it is required.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=privileged-containers"
+                            }
+                        },
+                        {
+                            "id": "run-as-non-root",
+                            "shortDescription": {
+                                "text": "Indicates when containers are not set to runAsNonRoot."
+                            },
+                            "fullDescription": {
+                                "text": "Set runAsUser to a non-zero number and runAsNonRoot to true in your pod or container securityContext. Refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for details."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=run-as-non-root-user",
+                            "help": {
+                                "text": "Check: run-as-non-root\nDescription: Indicates when containers are not set to runAsNonRoot.\nRemediation: Set runAsUser to a non-zero number and runAsNonRoot to true in your pod or container securityContext. Refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for details.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=run-as-non-root-user"
+                            }
+                        },
+                        {
+                            "id": "sensitive-host-mounts",
+                            "shortDescription": {
+                                "text": "Alert on deployments with sensitive host system directories mounted in containers"
+                            },
+                            "fullDescription": {
+                                "text": "Ensure sensitive host system directories are not mounted in containers by removing those Volumes and VolumeMounts."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=host-mounts",
+                            "help": {
+                                "text": "Check: sensitive-host-mounts\nDescription: Alert on deployments with sensitive host system directories mounted in containers\nRemediation: Ensure sensitive host system directories are not mounted in containers by removing those Volumes and VolumeMounts.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=host-mounts"
+                            }
+                        },
+                        {
+                            "id": "ssh-port",
+                            "shortDescription": {
+                                "text": "Indicates when deployments expose port 22, which is commonly reserved for SSH access."
+                            },
+                            "fullDescription": {
+                                "text": "Ensure that non-SSH services are not using port 22. Confirm that any actual SSH servers have been vetted."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=ports",
+                            "help": {
+                                "text": "Check: ssh-port\nDescription: Indicates when deployments expose port 22, which is commonly reserved for SSH access.\nRemediation: Ensure that non-SSH services are not using port 22. Confirm that any actual SSH servers have been vetted.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=ports"
+                            }
+                        },
+                        {
+                            "id": "unsafe-sysctls",
+                            "shortDescription": {
+                                "text": "Alert on deployments specifying unsafe sysctls that may lead to severe problems like wrong behavior of containers"
+                            },
+                            "fullDescription": {
+                                "text": "Ensure container does not allow unsafe allocation of system resources by removing unsafe sysctls configurations. For more details see https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ https://docs.docker.com/engine/reference/commandline/run/#configure-namespaced-kernel-parameters-sysctls-at-runtime."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=unsafe-sysctls",
+                            "help": {
+                                "text": "Check: unsafe-sysctls\nDescription: Alert on deployments specifying unsafe sysctls that may lead to severe problems like wrong behavior of containers\nRemediation: Ensure container does not allow unsafe allocation of system resources by removing unsafe sysctls configurations. For more details see https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ https://docs.docker.com/engine/reference/commandline/run/#configure-namespaced-kernel-parameters-sysctls-at-runtime.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=unsafe-sysctls"
+                            }
+                        },
+                        {
+                            "id": "unset-cpu-requirements",
+                            "shortDescription": {
+                                "text": "Indicates when containers do not have CPU requests and limits set."
+                            },
+                            "fullDescription": {
+                                "text": "Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=cpu-requirements",
+                            "help": {
+                                "text": "Check: unset-cpu-requirements\nDescription: Indicates when containers do not have CPU requests and limits set.\nRemediation: Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=cpu-requirements"
+                            }
+                        },
+                        {
+                            "id": "unset-memory-requirements",
+                            "shortDescription": {
+                                "text": "Indicates when containers do not have memory requests and limits set."
+                            },
+                            "fullDescription": {
+                                "text": "Set memory requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details."
+                            },
+                            "helpUri": "https://docs.kubelinter.io/#/generated/templates?id=memory-requirements",
+                            "help": {
+                                "text": "Check: unset-memory-requirements\nDescription: Indicates when containers do not have memory requests and limits set.\nRemediation: Set memory requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.\nTemplate: https://docs.kubelinter.io/#/generated/templates?id=memory-requirements"
+                            }
+                        }
+                    ],
+                    "version": "0.6.4"
+                }
+            },
+            "invocations": [
+                {
+                    "endTimeUtc": "2023-11-03T11:18:21.394592Z",
+                    "executionSuccessful": false,
+                    "workingDirectory": {
+                        "uri": "file:///Users/sauravsrijan/work/helm-charts"
+                    }
+                }
+            ],
+            "results": [
+                {
+                    "ruleId": "no-read-only-root-fs",
+                    "ruleIndex": 14,
+                    "message": {
+                        "text": "container \"kube-scheduler\" does not have a read-only root file system\nobject: \u003cno namespace\u003e/test-release-kube-scheduler apps/v1, Kind=Deployment"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/kube-scheduler/templates/deployment.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-kube-scheduler",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Deployment",
+                                    "fullyQualifiedName": "apps/v1, Kind=Deployment",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "run-as-non-root",
+                    "ruleIndex": 20,
+                    "message": {
+                        "text": "container \"kube-scheduler\" is not set to runAsNonRoot\nobject: \u003cno namespace\u003e/test-release-kube-scheduler apps/v1, Kind=Deployment"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/kube-scheduler/templates/deployment.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-kube-scheduler",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Deployment",
+                                    "fullyQualifiedName": "apps/v1, Kind=Deployment",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "latest-tag",
+                    "ruleIndex": 10,
+                    "message": {
+                        "text": "The container \"wget\" is using an invalid container image, \"busybox\". Please use images that are not blocked by the `BlockList` criteria : [\".*:(latest)$\" \"^[^:]*$\" \"(.*/[^:]+)$\"]\nobject: \u003cno namespace\u003e/test-release-runner-test-connection /v1, Kind=Pod"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/tests/test-connection.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-test-connection",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Pod",
+                                    "fullyQualifiedName": "/v1, Kind=Pod",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "no-read-only-root-fs",
+                    "ruleIndex": 14,
+                    "message": {
+                        "text": "container \"wget\" does not have a read-only root file system\nobject: \u003cno namespace\u003e/test-release-runner-test-connection /v1, Kind=Pod"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/tests/test-connection.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-test-connection",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Pod",
+                                    "fullyQualifiedName": "/v1, Kind=Pod",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "run-as-non-root",
+                    "ruleIndex": 20,
+                    "message": {
+                        "text": "container \"wget\" is not set to runAsNonRoot\nobject: \u003cno namespace\u003e/test-release-runner-test-connection /v1, Kind=Pod"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/tests/test-connection.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-test-connection",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Pod",
+                                    "fullyQualifiedName": "/v1, Kind=Pod",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "unset-cpu-requirements",
+                    "ruleIndex": 24,
+                    "message": {
+                        "text": "container \"wget\" has cpu request 0\nobject: \u003cno namespace\u003e/test-release-runner-test-connection /v1, Kind=Pod"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/tests/test-connection.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-test-connection",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Pod",
+                                    "fullyQualifiedName": "/v1, Kind=Pod",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "unset-cpu-requirements",
+                    "ruleIndex": 24,
+                    "message": {
+                        "text": "container \"wget\" has cpu limit 0\nobject: \u003cno namespace\u003e/test-release-runner-test-connection /v1, Kind=Pod"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/tests/test-connection.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-test-connection",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Pod",
+                                    "fullyQualifiedName": "/v1, Kind=Pod",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "unset-memory-requirements",
+                    "ruleIndex": 25,
+                    "message": {
+                        "text": "container \"wget\" has memory request 0\nobject: \u003cno namespace\u003e/test-release-runner-test-connection /v1, Kind=Pod"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/tests/test-connection.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-test-connection",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Pod",
+                                    "fullyQualifiedName": "/v1, Kind=Pod",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "unset-memory-requirements",
+                    "ruleIndex": 25,
+                    "message": {
+                        "text": "container \"wget\" has memory limit 0\nobject: \u003cno namespace\u003e/test-release-runner-test-connection /v1, Kind=Pod"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/tests/test-connection.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-test-connection",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Pod",
+                                    "fullyQualifiedName": "/v1, Kind=Pod",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "env-var-secret",
+                    "ruleIndex": 5,
+                    "message": {
+                        "text": "environment variable TASK_IMAGE_PULL_SECRET_NAME in container \"runner\" found\nobject: \u003cno namespace\u003e/test-release-runner apps/v1, Kind=Deployment"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/deployment.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Deployment",
+                                    "fullyQualifiedName": "apps/v1, Kind=Deployment",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "env-var-secret",
+                    "ruleIndex": 5,
+                    "message": {
+                        "text": "environment variable TASK_ARTIFACT_SECRET_NAME in container \"runner\" found\nobject: \u003cno namespace\u003e/test-release-runner apps/v1, Kind=Deployment"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/deployment.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Deployment",
+                                    "fullyQualifiedName": "apps/v1, Kind=Deployment",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "no-read-only-root-fs",
+                    "ruleIndex": 14,
+                    "message": {
+                        "text": "container \"runner\" does not have a read-only root file system\nobject: \u003cno namespace\u003e/test-release-runner apps/v1, Kind=Deployment"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/deployment.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Deployment",
+                                    "fullyQualifiedName": "apps/v1, Kind=Deployment",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "run-as-non-root",
+                    "ruleIndex": 20,
+                    "message": {
+                        "text": "container \"runner\" is not set to runAsNonRoot\nobject: \u003cno namespace\u003e/test-release-runner apps/v1, Kind=Deployment"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/deployment.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "Deployment",
+                                    "fullyQualifiedName": "apps/v1, Kind=Deployment",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "no-read-only-root-fs",
+                    "ruleIndex": 14,
+                    "message": {
+                        "text": "container \"runner-rqlite\" does not have a read-only root file system\nobject: \u003cno namespace\u003e/test-release-runner-rqlite apps/v1, Kind=StatefulSet"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/rqlite-statefulset.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-rqlite",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "StatefulSet",
+                                    "fullyQualifiedName": "apps/v1, Kind=StatefulSet",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "run-as-non-root",
+                    "ruleIndex": 20,
+                    "message": {
+                        "text": "container \"runner-rqlite\" is not set to runAsNonRoot\nobject: \u003cno namespace\u003e/test-release-runner-rqlite apps/v1, Kind=StatefulSet"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "charts/runner/templates/rqlite-statefulset.yaml"
+                                },
+                                "region": {
+                                    "startLine": 1
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "test-release-runner-rqlite",
+                                    "kind": "Object Name"
+                                },
+                                {
+                                    "name": "",
+                                    "kind": "Object Namespace"
+                                },
+                                {
+                                    "name": "apps",
+                                    "kind": "GVK/Group"
+                                },
+                                {
+                                    "name": "v1",
+                                    "fullyQualifiedName": "apps/v1",
+                                    "kind": "GVK/Version"
+                                },
+                                {
+                                    "name": "StatefulSet",
+                                    "fullyQualifiedName": "apps/v1, Kind=StatefulSet",
+                                    "kind": "GVK/Kind"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test_report_parsing.py
+++ b/tests/test_report_parsing.py
@@ -1,0 +1,50 @@
+import json
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Dict, Any
+
+import run_community_analyzer
+
+
+def make_artifact(report_path: str, workdir: str="") -> str:
+    """Return an artifact file for the given report, with the given workdir."""
+    artifact_path = tempfile.NamedTemporaryFile().name
+    # skipcq: PTC-W0064  # Report path is safe
+    with open(report_path) as report_file:
+        data = report_file.read()
+    with open(artifact_path, "w") as artifact_file:
+        json.dump({'data': data, 'metadata': {'work_dir': workdir}}, artifact_file)
+    return artifact_path
+
+
+@contextmanager
+def parse_single_artifact(report_path: str, report_name: str) -> Iterator[Dict[str, Any]]:
+    """Run community analyzer on a single artifact and return the deepsource result object."""
+    artifact_path = make_artifact(report_path)
+    toolbox_path = tempfile.gettempdir()
+    os.environ["ARTIFACTS_PATH"] = artifact_path
+    os.environ["TOOLBOX_PATH"] = toolbox_path
+    output_path = Path(toolbox_path, "analysis_results.json").as_posix()
+    run_community_analyzer.main([f"--analyzer={report_name}"])
+    with open(output_path) as output_file:
+        yield json.load(output_file)
+
+    os.remove(artifact_path)
+    os.remove(output_path)
+
+
+def test_sarif_parser() -> None:
+    """End to end test to make sure the SARIF parser throws no errors while parsing reports."""
+    # We parse all reports in `tests/fixtures/reports` and try to make a deepsource report out of it.
+    # There shouldn't be any errors while parsing the reports.
+    # All test reports are present in the `tests/fixtures/reports` directory.
+    reports_base_dir = Path.joinpath(Path(__file__).parent, "fixtures", "reports")
+    reports = os.listdir(reports_base_dir)
+    for report in reports:
+        report_tool = report.removesuffix(".sarif")
+        report_path = Path(reports_base_dir, report).as_posix()
+        with parse_single_artifact(report_path, report_tool) as result:
+            assert result
+            assert result["issues"] is not None

--- a/tests/test_report_parsing.py
+++ b/tests/test_report_parsing.py
@@ -3,24 +3,26 @@ import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Dict, Any
+from typing import Any, Dict, Iterator
 
 import run_community_analyzer
 
 
-def make_artifact(report_path: str, workdir: str="") -> str:
+def make_artifact(report_path: str, workdir: str = "") -> str:
     """Return an artifact file for the given report, with the given workdir."""
     artifact_path = tempfile.NamedTemporaryFile().name
     # skipcq: PTC-W0064  # Report path is safe
     with open(report_path) as report_file:
         data = report_file.read()
     with open(artifact_path, "w") as artifact_file:
-        json.dump({'data': data, 'metadata': {'work_dir': workdir}}, artifact_file)
+        json.dump({"data": data, "metadata": {"work_dir": workdir}}, artifact_file)
     return artifact_path
 
 
 @contextmanager
-def parse_single_artifact(report_path: str, report_name: str) -> Iterator[Dict[str, Any]]:
+def parse_single_artifact(
+    report_path: str, report_name: str
+) -> Iterator[Dict[str, Any]]:
     """Run community analyzer on a single artifact and return the deepsource result object."""
     artifact_path = make_artifact(report_path)
     toolbox_path = tempfile.gettempdir()

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py311,py311-mypy
 [testenv]
 deps = -rrequirements-dev.txt
 setenv = PYTHONPATH=.
-commands = pytest --cov=./ --cov-report=xml
+commands = pytest --cov=./ --cov-report=xml --cov-branch
 
 [testenv:py311-mypy]
 description = Type check with mypy


### PR DESCRIPTION
Changes:
  - Add end to end parsing test
  - Fix assets being copied in the Dockerfile
  - Explicitly log the info passed to sentry.raise_info
  - Add instruction about adding fixture for parsing test in readme