### PR TITLE
fix: always parse CLI args so issue map loads for community analyzers

### DIFF
--- a/run_community_analyzer.py
+++ b/run_community_analyzer.py
@@ -65,11 +65,10 @@ def main(argv: list[str] | None = None) -> None:
         help="Which community analyzer to run. Example: 'kube-linter'",
         required=False,
     )
-    if argv:
-        args = parser.parse_args(argv, namespace=CommunityAnalyzerArgs)
-        # analyzer name is mandatory in case of community analyzers but not custom analyzers
-        if analyzer_name := args.analyzer:
-            issue_map_path = get_issue_map(analyzer_name)
+    args = parser.parse_args(argv, namespace=CommunityAnalyzerArgs)
+    # analyzer name is mandatory in case of community analyzers but not custom analyzers
+    if analyzer_name := args.analyzer:
+        issue_map_path = get_issue_map(analyzer_name)
 
     modified_files = get_files_to_analyze(code_path)
     run_sarif_parser(

--- a/run_community_analyzer.py
+++ b/run_community_analyzer.py
@@ -65,7 +65,7 @@ def main(argv: list[str] | None = None) -> None:
         help="Which community analyzer to run. Example: 'kube-linter'",
         required=False,
     )
-    args = parser.parse_args(argv, namespace=CommunityAnalyzerArgs)
+    args = parser.parse_args(argv, namespace=CommunityAnalyzerArgs())
     # analyzer name is mandatory in case of community analyzers but not custom analyzers
     if analyzer_name := args.analyzer:
         issue_map_path = get_issue_map(analyzer_name)

--- a/tests/test_community_analyzer.py
+++ b/tests/test_community_analyzer.py
@@ -423,14 +423,14 @@ def test_community_analyzer_without_issue_map(tmp_path: Path) -> None:
 
     # Case: when analysis config is not present, it should raise an error.
     with pytest.raises(ValueError) as exe:
-        run_community_analyzer.main()
+        run_community_analyzer.main([])
     assert (
         str(exe.value) == f"Could not find analysis config at {analysis_config_path}."
     )
 
     # Case: all files from the report are present in the analysis config.
     with temp_analysis_config(analysis_config_path, modified_files):
-        run_community_analyzer.main()
+        run_community_analyzer.main([])
 
     analysis_results = tmp_path / "analysis_results.json"
     assert analysis_results.exists()
@@ -447,7 +447,7 @@ def test_community_analyzer_without_issue_map(tmp_path: Path) -> None:
         os.path.join(code_path, "charts/runner/templates/tests/test-connection.yaml"),
     ]
     with temp_analysis_config(analysis_config_path, modified_files):
-        run_community_analyzer.main()
+        run_community_analyzer.main([])
 
     analysis_results = tmp_path / "analysis_results.json"
     assert analysis_results.exists()


### PR DESCRIPTION
## Summary

- The `if argv:` guard added in #29 prevented `argparse` from reading `sys.argv` when the script runs via `__main__` (where `argv` defaults to `None`). This caused `--analyzer=<name>` to be silently ignored, the issue map was never loaded, and every rule lookup failed with `"Sanitized issues count, with id in map: 0"`.
- Remove the guard so `parse_args(argv)` always runs. When `argv` is `None`, argparse falls back to `sys.argv[1:]`. Custom analyzers still work because `args.analyzer` is `None` when `--analyzer` isn't passed.

### Test fixes

- **Pass `[]` instead of no args in the no-issue-map test:** `main()` with no args means `parse_args(None)` which reads `sys.argv[1:]` — in a test runner this contains pytest's own flags (`--cov`, etc.), causing argparse to error. Passing `[]` explicitly means "zero CLI arguments."

- **Use `CommunityAnalyzerArgs()` instance instead of the class:** argparse only sets defaults when the attribute doesn't already exist on the namespace. Using the class directly meant `analyzer="kube-linter"` set by `test_community_analyzer` persisted as a class attribute and leaked into `test_community_analyzer_without_issue_map`, causing it to load the kube-linter issue map even without `--analyzer`.

## Test plan

- [x] Existing tests pass (`test_community_analyzer` and `test_community_analyzer_without_issue_map`)
- [x] Deploy and verify `Sanitized issues count` is > 0 for community analyzer runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)